### PR TITLE
Add EULA acceptance to test bootstrap script

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -13,4 +13,4 @@ password=testing
 orgaccount=kitchen
 
 echo "Configuring for master..."
-docker exec conjur-appliance evoke configure master -h $hostname -p $password $orgaccount
+docker exec conjur-appliance evoke configure master --accept-eula -h $hostname -p $password $orgaccount


### PR DESCRIPTION
This PR updates the test `bootstrap.sh` script to add EULA acceptance to this master configuration.